### PR TITLE
[ADD] Get version from /builds request

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ To get the app id you can either navigate to your app in the App Store with your
 5. Enter the name of your key (e.g. `your-app-name-api-key`) and select the desired role (e.g. `Developer`).
 6. A new key will appear in your Keys list.
 7. Tap "**Download API Key**" to download the `AuthKey_{key-id}.p8` file.  
-**Note**: You won't be able to download it afterwards.
+   **Note**: You won't be able to download it afterwards.
 8. Copy **Issuer ID** and **Key ID** on the same page.  
-**Note**: You will be able to copy them afterwards.
+   **Note**: You will be able to copy them afterwards.
 
 **Note**: It's suggested to store the sensitive information (like json web token, private key, key id and issuer id) as **[Github Secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets)** (please check also **[how to store files as secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets#storing-base64-binary-blobs-as-secrets)**).
 
@@ -102,7 +102,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        
+
       - name: Get App Store Version with iTunes Lookup
         id: appstore_version
         uses: action-tools/get-appstore-version@v1.3
@@ -111,7 +111,7 @@ jobs:
           bundle-id: ${{ secrets.BUNDLE_ID }}
           use-https: true
           itunes-lookup-try-api-on-failure: false
-        
+
       - name: Get App Store Version with AppStore Connect API
         id: appstore_version
         uses: action-tools/get-appstore-version@v1.3
@@ -123,7 +123,7 @@ jobs:
           private-key-raw: ${{ secrets.PRIVATE_KEY_RAW }}
           private-key-p8-base64: ${{ secrets.PRIVATE_KEY_FILE_BASE64 }}
           private-key-p8-path: ./AuthKey.p8
-          
+
       - name: Get results
         run: |
           echo "App Store latest version: ${{ steps.appstore_version.outputs.app-version-latest }}"
@@ -142,7 +142,7 @@ You can find some samples **[here](https://github.com/action-tools/app-latest-ve
 ## Action Inputs
 
 | Input                              | Required | Default | Description                                                                           |
-| :---                               | :---     | :---    | :---                                                                                  |
+|:-----------------------------------| :---     | :---    |:--------------------------------------------------------------------------------------|
 | `is-itunes-lookup`                 | false    | `false` | Should action use iTunes lookup endpoint or AppStore Connect API.                     |
 | `bundle-id`                        | false    |         | Application bundle id (required for iTunes lookup only).                              |
 | `use-https`                        | false    | `true`  | Use HTTPS or HTTP (for iTunes lookup only).                                           |
@@ -154,6 +154,7 @@ You can find some samples **[here](https://github.com/action-tools/app-latest-ve
 | `private-key-p8-path`              | false    |         | Private key file downloaded from the API Keys page in App Store Connect (\*.p8 file). |
 | `private-key-p8-base64`            | false    |         | Private key downloaded from the App Store Connect (\*.p8 file) in Base64 format.      |
 | `private-key-raw`                  | false    |         | Raw private key downloaded from the API Keys page in App Store Connect.               |
+| `from-build`                       | false    |         | Read version of build                                                                 |
 
 ## Action Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: 'App Store Connect Application Version'
 description: 'Get latest and previous versions of application from the App Store Connect'
 branding:
-  icon: 'smartphone'  
+  icon: 'smartphone'
   color: 'blue'
 inputs:
   is-itunes-lookup:
@@ -52,6 +52,10 @@ inputs:
     description: 'Number of versions to return. Maximum value is 200.'
     required: false
     default: '2'
+  from-build:
+    description: 'Read version from build (for App Store Connect only)'
+    required: false
+    default: ''
 outputs:
   app-version-latest:
     description: 'Latest app version'

--- a/src/index.js
+++ b/src/index.js
@@ -69,18 +69,23 @@ async function appstoreConnectApi() {
 
     const utils = new Utils()
 
+    const path = core.getInput('from-build')
+        ? `/v1/builds?filter[app]=${appId}`
+        : `/v1/apps/${appId}/appStoreVersions`;
+
     const tokenString = utils.getToken(
-      appId,
-      issuerId,
-      keyId,
-      jsonWebToken,
-      privateKeyRaw,
-      privateKeyFilePath,
-      privateKeyFileBase64)
+        appId,
+        issuerId,
+        keyId,
+        jsonWebToken,
+        privateKeyRaw,
+        privateKeyFilePath,
+        privateKeyFileBase64,
+        `GET ${path}`)
 
     const limit = utils.getLimit(versionsLimit)
     console.log(messages.sending_appstore_connect_request)
-    const jsonObject = await appstoreConnectApiRequest(appId, tokenString, limit)
+    const jsonObject = await appstoreConnectApiRequest(path, tokenString, limit)
 
     if (jsonObject.errors !== undefined && jsonObject.errors.length > 0) {
       const error = jsonObject.errors[0];
@@ -142,7 +147,7 @@ function setOutput(data, index) {
     throw new Error(message)
   }
 
-  const version = attributes.versionString
+  const version = attributes.versionString ?? attributes.version
   const state = attributes.appStoreState
   const releaseType = attributes.releaseType
   const createdDate = attributes.createdDate

--- a/src/request.js
+++ b/src/request.js
@@ -1,7 +1,7 @@
 import fetch from 'node-fetch'
 
-export const appstoreConnectApiRequest = async (appId, jwt, limit) => {
-  const url = `https://api.appstoreconnect.apple.com/v1/apps/${appId}/appStoreVersions?limit=${limit}`
+export const appstoreConnectApiRequest = async (path, jwt, limit) => {
+  const url = `https://api.appstoreconnect.apple.com${path}?limit=${limit}`
   const response = await fetch(url, { headers: { 'Authorization': `Bearer ${jwt}` } })
   return await response.json()
 }

--- a/src/token.js
+++ b/src/token.js
@@ -16,18 +16,17 @@ export default class Token {
       const keyFilename = 'authkey.p8'
       const buffer = Buffer.from(keyFileBase64, 'base64')
       fs.writeFileSync(keyFilename, buffer)
-      this.privateKey = fs.readFileSync(keyFilename)      
+      this.privateKey = fs.readFileSync(keyFilename)
       console.log(messages.using_base64_private_key)
     } else {
       throw new Error(messages.appstore_connect_setup_error)
     }
   }
 
-  generate(appId, issuerId, keyId) {
+  generate(appId, issuerId, keyId, scope) {
     const exp = '20m'
     const alg = 'ES256'
     const aud = 'appstoreconnect-v1'
-    const scope = `GET /v1/apps/${appId}/appStoreVersions`
     const payload = { iss: issuerId, aud: aud, scope: [scope] }
     const jwtOptions = { expiresIn: exp, algorithm: alg, header: { kid: keyId } }
     return jwt.sign(payload, this.privateKey, jwtOptions)

--- a/src/utils.js
+++ b/src/utils.js
@@ -8,7 +8,7 @@ export default class Utils {
     this.defaultLimit = 2
   }
 
-  getToken(appId, issuerId, keyId, jwt, pkRaw, pkFilePath, pkFileBase64) {
+  getToken(appId, issuerId, keyId, jwt, pkRaw, pkFilePath, pkFileBase64, scope) {
     if (!!jwt) {
       console.log(messages.predefined_jwt_set)
       return jwt
@@ -18,7 +18,7 @@ export default class Utils {
     console.log(messages.setting_private_key)
     const token = new Token(pkRaw, pkFilePath, pkFileBase64)
     console.log(messages.automatic_token_generation)
-    return token.generate(appId, issuerId, keyId)
+    return token.generate(appId, issuerId, keyId, scope)
   }
 
   getLimit(limitInput) {


### PR DESCRIPTION
### Description of change

Add ability to read version not from app version, but from build version.
It's very convenient when you have many rejected versions available only in TestFlight
